### PR TITLE
Adds niyoj as a participant #5

### DIFF
--- a/data/participants.json
+++ b/data/participants.json
@@ -1583,6 +1583,16 @@
     "github" : "https://github.com/devmrfitz",
     "twitter" : "",
     "referral" : ""
+ },
+ {
+   "name" : "Niyoj Oli",
+   "imageurl" : "https://avatars.githubusercontent.com/u/84063586",
+   "about" : "Hello I'm a first year undergraduate student who is very interested to learn new things and contribute to open source.",
+   "college" : "Thapathali Engineering Campus, Nepal",
+   "facebook" : "https://www.fb.com/oli.niyoj",
+   "github" : "https://github.com/niyoj",
+   "twitter" : "",
+   "referral": ""
  }
 
 ]


### PR DESCRIPTION
Issue: 5

#### Short description of what this resolves:
It adds the participant `niyoj` inside the `./data/participants.json`.


#### Changes proposed in this pull request and/or Screenshots of changes:

- Inside `./data/participants.json` a new code block was created and the values were updated as per the given template.