### PR TITLE
Added GithubResume

### DIFF
--- a/data/participants/MaqsudMallick.json
+++ b/data/participants/MaqsudMallick.json
@@ -1,0 +1,4 @@
+{
+    "name": "Maqsud Mallick",
+    "github resume": "https://resume.github.io/?MaqsudMallick"
+}


### PR DESCRIPTION
Issue: 129

Short description of what this resolves:
Added details of my github resume is a .json file inside the data>participants directory.

 Changes proposed in this pull request and/or Screenshots of changes:

-
-
-